### PR TITLE
Make settings.gradle work on windows and linux/mac

### DIFF
--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -33,6 +33,12 @@ object.plugins.android.each { androidPlugin ->
   if(androidPlugin.name == 'nordic_nrf_mesh'){
     println 'should include forked Nordic\'s ADK v3'
     def meshLibPath = androidPlugin.path.replace('android', '') + 'Android-nRF-Mesh-Library-1\\mesh\\'
+    if (System.properties['os.name'].toLowerCase().contains('windows')) {
+      println "detected running on Windows"
+    } else {
+      println "detected running on non Windows (linux or mac)"
+      meshLibPath = meshLibPath.replace('\\', '/')
+    }
     println 'meshLibPath = ' + meshLibPath
     include ':mesh'
     project(':mesh').projectDir = file(meshLibPath)


### PR DESCRIPTION
When I tried to install this library using `flutter pub get nrf_mesh_plugin` - I encountered an issue where I couldn't import the library to my code.

I found an error in the code `Failed to resolve: project :mesh`

I found that fixing the `meshLibPath` slashes match the OS that it's running on.